### PR TITLE
Add custom power scaling

### DIFF
--- a/src/main/java/cofh/redstonearsenal/init/RAEquipment.java
+++ b/src/main/java/cofh/redstonearsenal/init/RAEquipment.java
@@ -64,6 +64,13 @@ public class RAEquipment {
 	/* MATERIALS */
 	public static ArmorMaterial armorMaterialFlux;
 	public static ToolMaterial toolMaterialFlux;
+	
+	/* COSTS */
+	public static int basePower;
+	public static int toolPowerScale;
+	public static int armorPowerScale;
+	public static int empowerScale;
+	public static int multiblockScale;
 
 	static {
 		String category;
@@ -76,6 +83,32 @@ public class RAEquipment {
 
 		int harvestLevel = 4;
 		float efficiency = 8.0F;
+		
+		baseCost = 200;
+		toolPowerScale = 100;
+		armorPowerScale = 100;
+		empowerScale = 400;
+		multiblockScale = 200;
+		
+		category = "Equipment";
+		comment = "Base Power per usage.";
+		RedstoneArsenal.CONFIC.getConfiguration().getInt("BasePower", category, baseCost, 100, 3600, comment);
+		
+		category = "Equipment.CustomPowerScaling";
+		comment = "ADVANCED FEATURE - ONLY EDIT IF YOU KNOW WHAT YOU ARE DOING.\nValues are expressed as a percentage of Base Power; Base Scale Factor is 100 percent.\nValue will be rounded down to the nearest 10.";
+		RedstoneArsenal.CONFIG.getCategory(category).setComment(comment);
+		
+		comment = "Scale Factor for Tool usage.";
+		toolPowerScale = RedstoneArsenal.CONFIG.getConfiguration().getInt("Tools", category, toolPowerScale, 10, 1000, comment);
+		
+		comment = "Scale Factor for Armor usage.";
+		armorPowerScale = RedstoneArsenal.CONFIG.getConfiguration().getInt("Armor", category, armorPowerScale, 10, 1000, comment);
+		
+		comment = "Scale Factor for Empowered usage.";
+		empowerScale = RedstoneArsenal.CONFIG.getConfiguration().getInt("Empowered", category, empowerScale, 100, 3600, comment);
+		
+		comment = "Scale Factor for Axe, Hammer, Excavator, and Sickle usage. This only applies in Empowered mode, and is applied in addition to the Tools Scale Factor.";
+		multiblockScale = RedstoneArsenal.CONFIG.getConfiguration().getInt("MultiblockTools", category, multiblockScale, 100, 1000, comment);
 
 		category = "Equipment.Armor";
 		comment = "Adjust this value to set the default protection provided by the Flux-Infused Boots.";
@@ -99,6 +132,13 @@ public class RAEquipment {
 
 		armorMaterialFlux = EnumHelper.addArmorMaterial("RA:FLUXELECTRUM", "flux_armor", 100, new int[] { boots, legs, chest, helm }, 20, SoundEvents.ITEM_ARMOR_EQUIP_IRON, 2.0F);
 		toolMaterialFlux = EnumHelper.addToolMaterial("RA:FLUXELECTRUM", harvestLevel, 100, efficiency, 0, 25);
+		
+		baseCost = (baseCost / 10) * 10;
+		toolPowerScale = (toolPowerScale / 10) * 10;
+		armorPowerScale = (armorPowerScale / 10) * 10;
+		empowerScale = (empowerScale / 10) * 10;
+		multiblockScale = (multiblockScale / 10) * 10;
+		
 	}
 
 	/* ARMOR */

--- a/src/main/java/cofh/redstonearsenal/item/tool/ItemAxeFlux.java
+++ b/src/main/java/cofh/redstonearsenal/item/tool/ItemAxeFlux.java
@@ -2,6 +2,7 @@ package cofh.redstonearsenal.item.tool;
 
 import cofh.core.init.CoreEnchantments;
 import cofh.core.item.IEnchantableItem;
+import cofh.redstonearsenal.init.RAEquipment;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
@@ -24,7 +25,7 @@ public class ItemAxeFlux extends ItemToolFlux implements IEnchantableItem {
 		addToolClass("axe");
 		damage = 7;
 		damageCharged = 6;
-		energyPerUseCharged = 1600;
+		energyPerUseCharged = energyPerUseCharged * RAEquipment.multiblockScale / 100;
 
 		effectiveBlocks.addAll(ItemAxe.EFFECTIVE_ON);
 

--- a/src/main/java/cofh/redstonearsenal/item/tool/ItemExcavatorFlux.java
+++ b/src/main/java/cofh/redstonearsenal/item/tool/ItemExcavatorFlux.java
@@ -3,6 +3,7 @@ package cofh.redstonearsenal.item.tool;
 import cofh.core.init.CoreProps;
 import cofh.core.item.IAOEBreakItem;
 import cofh.core.util.RayTracer;
+import cofh.redstonearsenal.init.RAEquipment;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
@@ -23,7 +24,7 @@ public class ItemExcavatorFlux extends ItemToolFlux implements IAOEBreakItem {
 		addToolClass("shovel");
 		addToolClass("excavator");
 		damage = 4;
-		energyPerUseCharged = 1600;
+		energyPerUseCharged = energyPerUseCharged * RAEquipment.multiblockScale / 100;
 
 		effectiveBlocks.addAll(ItemSpade.EFFECTIVE_ON);
 

--- a/src/main/java/cofh/redstonearsenal/item/tool/ItemHammerFlux.java
+++ b/src/main/java/cofh/redstonearsenal/item/tool/ItemHammerFlux.java
@@ -3,6 +3,7 @@ package cofh.redstonearsenal.item.tool;
 import cofh.core.init.CoreProps;
 import cofh.core.item.IAOEBreakItem;
 import cofh.core.util.RayTracer;
+import cofh.redstonearsenal.init.RAEquipment;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
@@ -24,7 +25,7 @@ public class ItemHammerFlux extends ItemToolFlux implements IAOEBreakItem {
 		addToolClass("hammer");
 		damage = 9;
 		damageCharged = 6;
-		energyPerUseCharged = 1600;
+		energyPerUseCharged = energyPerUseCharged * RAEquipment.multiblockScale / 100;
 
 		effectiveBlocks.addAll(ItemPickaxe.EFFECTIVE_ON);
 

--- a/src/main/java/cofh/redstonearsenal/item/tool/ItemSickleFlux.java
+++ b/src/main/java/cofh/redstonearsenal/item/tool/ItemSickleFlux.java
@@ -1,5 +1,6 @@
 package cofh.redstonearsenal.item.tool;
 
+import cofh.redstonearsenal.init.RAEquipment;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
@@ -18,7 +19,7 @@ public class ItemSickleFlux extends ItemToolFlux {
 		addToolClass("sickle");
 		damage = 4;
 		damageCharged = 6;
-		energyPerUseCharged = 1200;
+		energyPerUseCharged = energyPerUseCharged * RAEquipment.multiblockScale / 100;
 
 		effectiveBlocks.add(Blocks.WEB);
 		effectiveBlocks.add(Blocks.VINE);

--- a/src/main/java/cofh/redstonearsenal/item/tool/ItemToolFlux.java
+++ b/src/main/java/cofh/redstonearsenal/item/tool/ItemToolFlux.java
@@ -9,6 +9,7 @@ import cofh.core.util.helpers.DamageHelper;
 import cofh.core.util.helpers.EnergyHelper;
 import cofh.core.util.helpers.MathHelper;
 import cofh.core.util.helpers.StringHelper;
+import cofh.redstonearsenal.init.RAEquipment;
 import cofh.redstonearsenal.init.RAProps;
 import cofh.redstoneflux.api.IEnergyContainerItem;
 import cofh.redstoneflux.util.EnergyContainerItemWrapper;
@@ -46,8 +47,8 @@ public abstract class ItemToolFlux extends ItemToolCore implements IEnchantableI
 	protected int maxEnergy = 320000;
 	protected int maxTransfer = 4000;
 
-	protected int energyPerUse = 200;
-	protected int energyPerUseCharged = 800;
+	protected int energyPerUse = RAEquipment.basePower * RAEquipment.toolPowerScale / 100;
+	protected int energyPerUseCharged = energyPerUse * RAEquipment.empoweredScale / 100;
 
 	protected int damage;
 	protected int damageCharged = 4;


### PR DESCRIPTION
The custom power scaling configuration behaves the same as in thermal expansion.

The defaults have been chosen such that all costs stay the same, except that the sickle now costs 1,600RF in empowered mode instead of 1,200RF.

I tried my best to maintain the same code style as the rest of the cofh mods.

I was not able to figure out how to comiple this mod, so I couldn't test my changes, or even confirm that it compiles. I checked my code over several times to try and spot any issues that may occur.

I am open to alternate implementation ideas or changes; I mostly wanted a way to scale the power cost from 200RF to 3,000RF per use. You are welcome to push to my branch if you want to.