### PR TITLE
Enable Energetic Infuser if Thermal series is installed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ dependencies {
     implementation fg.deobf("com.teamcofh:cofh_core:${mc_version}-${cofh_core_version}.+")
 
     compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}:api")
+    compileOnly fg.deobf("com.teamcofh:thermal_core:${mc_version}-${thermal_core_version}.+")
 }
 
 signing {

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,9 @@ forge_version=43.1.1
 cofh_core_version=10.2.0
 cofh_core_max_version=10.3.0
 
+thermal_core_version=10.2.0
+thermal_core_max_version=10.3.0
+
 jei_version=11.6.0+
 curios_version=1.19-5.1.0.1
 

--- a/src/main/java/cofh/redstonearsenal/RedstoneArsenal.java
+++ b/src/main/java/cofh/redstonearsenal/RedstoneArsenal.java
@@ -4,9 +4,11 @@ import cofh.core.config.ConfigManager;
 import cofh.core.event.CoreClientEvents;
 import cofh.lib.network.PacketHandler;
 import cofh.lib.util.DeferredRegisterCoFH;
+import cofh.lib.util.Utils;
 import cofh.redstonearsenal.capability.CapabilityFluxShielding;
 import cofh.redstonearsenal.config.RSAConfig;
 import cofh.redstonearsenal.init.*;
+import cofh.redstonearsenal.util.ThermalCoreCompat;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.EntityType;
@@ -70,6 +72,9 @@ public class RedstoneArsenal {
         RSAEntities.register();
         RSAPackets.register();
         RSASounds.register();
+
+        if(Utils.isModLoaded("thermal"))
+            ThermalCoreCompat.setFeatureFlags();
     }
 
     // region INITIALIZATION

--- a/src/main/java/cofh/redstonearsenal/util/ThermalCoreCompat.java
+++ b/src/main/java/cofh/redstonearsenal/util/ThermalCoreCompat.java
@@ -1,0 +1,10 @@
+package cofh.redstonearsenal.util;
+
+import cofh.thermal.lib.common.ThermalFlags;
+import cofh.thermal.lib.common.ThermalIDs;
+
+public class ThermalCoreCompat {
+    public static void setFeatureFlags() {
+        ThermalFlags.setFlag(ThermalIDs.ID_CHARGE_BENCH, true);
+    }
+}


### PR DESCRIPTION
If Thermal Innovation is not installed but other Thermal series mods are, the Energetic Infuser will not be available. As a CoFH mod that provides equipment that uses RF, it would be useful for RSA to enable it.

The setFeatureFlags method is a static method of a separate class in order to avoid being classloaded if Thermal Core is not installed.